### PR TITLE
Demo project gets installed, too.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name='dinette',
     description='Dinette is a forum application in the spirit of PunBB.',
     keywords='django, forum',
-    packages=find_packages(),
+    packages=find_packages(exclude=["forum", "forum.*"]),
     include_package_data=True,
     zip_safe=False,
     version="1.2",


### PR DESCRIPTION
I suppose this is a bug since it installs the 'forum' project in the site-packages, too.

The fix won't actual exclude the package from tarball, so you can still point to it in the docs as an example.
